### PR TITLE
Apply file transforms before processing them

### DIFF
--- a/System.Web.Optimization.Less/LessTransform.cs
+++ b/System.Web.Optimization.Less/LessTransform.cs
@@ -76,7 +76,7 @@ namespace System.Web.Optimization
                 }
 
                 this.SetCurrentFilePath(lessParser, filePath);
-                var source = File.ReadAllText(filePath);
+                var source = bundleFile.ApplyTransforms();
                 content.Append(lessEngine.TransformToCss(source, filePath));
                 content.AppendLine();
 


### PR DESCRIPTION
Fixes the case where you ask for a transform when bundling your files
(CssRewriteUrlTransform, for example, as in "new
LessBundle("~/bundles/css").Include("~/Content/site.less", new
CssRewriteUrlTransform())") : the previous code reads the file from
disk, omitting to apply the transforms. This is now fixed.
