### PR TITLE
Uncommented setting of bundle response files back.

### DIFF
--- a/System.Web.Optimization.Less/LessTransform.cs
+++ b/System.Web.Optimization.Less/LessTransform.cs
@@ -57,13 +57,13 @@ namespace System.Web.Optimization
 
             IEnumerable<BundleFile> bundleFiles = bundleResponse.Files;
             bundleResponse.Content = Process(ref bundleFiles);
-            bundleResponse.Files = bundleFiles; // Need to save changed bundle files.
 
             // set bundle response files back (with imported ones)
-            /*if (context.EnableOptimizations)
+            if (context.EnableOptimizations)
             {
                 bundleResponse.Files = bundleFiles;
-            }*/
+            }
+
             bundleResponse.ContentType = "text/css";
         }
 


### PR DESCRIPTION
When those lines were commented, less bundle worked incorrectly when optimizations are turned on.
In my project I have _main.less_ file:

``` less
@import "main-variables.less";
// styles
```

_main-variables.less_:

``` less
@foobar: 20px;
// other variables
```

and my _BundleConfig.cs_:

``` c#
bundles.Add(new LessBundle("~/bundles/css").Include("~/Content/pages/main/main.less"));
```

With original version of the code (where lines are commented) output of _main.less_ never changes if I change variables from _main-variables.less_ (bundle optimizations shall be turned on).
With my changes this problem disappears.
