### PR TITLE
Re-init the Less engine for each file

### DIFF
--- a/System.Web.Optimization.Less/LessTransform.cs
+++ b/System.Web.Optimization.Less/LessTransform.cs
@@ -79,15 +79,18 @@ namespace System.Web.Optimization
             // system.Web.Optimization cache is used instead
             lessConfig.CacheEnabled = false;
 
-            ILessEngine lessEngine = LessWeb.GetEngine(lessConfig);
-            LessEngine underlyingLessEngine = lessEngine.ResolveLessEngine();
-            Parser lessParser = underlyingLessEngine.Parser;
             var content = new StringBuilder();
 
             var targetFiles = new List<BundleFile>();
 
             foreach (BundleFile bundleFile in files)
             {
+                // initialize the less engine once for each file.
+                // this is to prevent leaking state between files
+                ILessEngine lessEngine = LessWeb.GetEngine(lessConfig);
+                LessEngine underlyingLessEngine = lessEngine.ResolveLessEngine();
+                Parser lessParser = underlyingLessEngine.Parser;
+
                 targetFiles.Add(bundleFile);
                 string filePath = bundleFile.IncludedVirtualPath;
                 filePath = filePath.Replace('\\', '/');


### PR DESCRIPTION
This fixes #24.

Re-initializing the LessEngine for each file in the bundle we process prevents previous state from leaking between different files in the bundle. This also matches how the DotLess console app works.